### PR TITLE
Replace "left single quote" with "apostrophe"

### DIFF
--- a/mainmatter/community-tutorials/simple-oodb.tex
+++ b/mainmatter/community-tutorials/simple-oodb.tex
@@ -98,12 +98,12 @@ better than me:
   \texttt{`\}}'). The characters of the symbol's name itself identify
   the physical location of the external object. This is currently the
   number of the starting block in the database file, encoded in
-  base--64 notation (characters `\texttt{0}′ through ‘\texttt{9}′,
-  ‘\texttt{:}' through ‘\texttt{;}', `\texttt{A}' through `\texttt{Z}'
+  base--64 notation (characters `\texttt{0}′ through `\texttt{9}',
+  `\texttt{:}' through `\texttt{;}', `\texttt{A}' through `\texttt{Z}'
   and `\texttt{a}' through `\texttt{z}').
 \end{quote}
 
-Instead of \texttt{(show ‘\{2\})} try:
+Instead of \texttt{(show '\{2\})} try:
 
 
 \begin{wideverbatim}


### PR DESCRIPTION
The left single quote wasn't rendering properly in the copy of the PDF I have.
